### PR TITLE
1.14 support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  RELEASE_TITLE: "Set Spawn 1.15.2 - build ${{github.run_number}}"
+  RELEASE_TITLE: "Set Spawn - build ${{github.run_number}}"
   RELEASE_TAG: "v${{github.run_number}}"
   RELEASE_FILE: "build/libs/*-v${{github.run_number}}.jar"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.0-SNAPSHOT'
+	id 'fabric-loom' version '1.3-SNAPSHOT'
 	id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
@@ -27,7 +27,7 @@ def getVersionMetadata() {
 	return "rev.${id}"
 }
 
-archivesBaseName = "${project.mod_id}-${project.minecraft_version}"
+archivesBaseName = "${project.mod_id}-${project.target_version}"
 version = "${getVersionMetadata()}"
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 mod_id=setspawnmod
-minecraft_version=1.15.2
-yarn_mappings=1.15.2+build.17
-loader_version=0.12.2
+minecraft_version=1.14.4
+target_version=1.14-1.15
+yarn_mappings=1.14.4+build.18
+loader_version=0.14.21

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/set/spawn/mod/SetSpawn.java
+++ b/src/main/java/net/set/spawn/mod/SetSpawn.java
@@ -44,15 +44,11 @@ public class SetSpawn implements ClientModInitializer {
     }
 
     private static void writeDefaultProperties(File file) throws IOException {
-        Seed vine = new Seed("8398967436125155523", "vine", -201.5, 229.5);
-        Seed taiga = new Seed("2483313382402348964", "taiga", -233.5, 249.5);
-        Seed gravel = new Seed("-3294725893620991126", "gravel", 161.5, 194.5);
-        Seed dolphin = new Seed("-4530634556500121041", "dolphin", 174.5, 201.5);
-        Seed treasure = new Seed("7665560473511906728", "treasure", 90.5, 218.5);
+        Seed desert = new Seed("8398967436125155523", "desert", 0, 0);
         Seed rng = new Seed("-4810268054211229692", "rng", -153.5, 234.5);
         Seed arch = new Seed("2613428371297940758", "arch", -154.5, -217.5);
         Seed fletcher = new Seed("2478133068685386821", "fletcher", -248.5, 106.5);
-        Seed[] seedsToWrite = new Seed[] { vine, taiga, gravel, dolphin, treasure, rng, arch, fletcher };
+        Seed[] seedsToWrite = new Seed[]{desert, rng, arch, fletcher};
         Config config = new Config(true, false, seedsToWrite);
 
         try (Writer writer = new FileWriter(file)) {

--- a/src/main/java/net/set/spawn/mod/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/net/set/spawn/mod/mixin/ServerPlayerEntityMixin.java
@@ -27,7 +27,8 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Co
         super(world, profile);
     }
 
-    @Inject(method = "moveToSpawn", at = @At("HEAD"), cancellable = true)
+    // method_14245 == moveToSpawn, intermediary method is matched between the whole range but was only named beginning in 1.15 mappings
+    @Inject(method = "method_14245", at = @At("HEAD"), cancellable = true)
     public void setspawnmod_setSpawn(ServerWorld world, CallbackInfo ci) {
         if (SetSpawn.shouldModifySpawn) {
             SetSpawn.shouldModifySpawn = false;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "${mod_id}",
   "version": "${version}",
 
-  "name": "Set Spawn 1.15.2",
+  "name": "Set Spawn 1.14-1.15",
   "description": "Sets the player's spawnpoint in SSG to specified coordinates.",
   "authors": [
     "bdamja",
@@ -24,8 +24,8 @@
     "setspawnmod.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.12.2",
-    "minecraft": "~1.15"
+    "fabricloader": ">=0.12.12",
+    "minecraft": ">=1.14 <1.16"
   },
   "breaks": {
     "worldpreview": "*"


### PR DESCRIPTION
## Description
- added support for 1.14 (only changed `fabric.mod.json`)
  - tested in 1.14.4 and 1.15.2, mod works as intended
- added desert seed to config, removed irrelevant 1.16+ seeds

Checklist
- [x] Build compiles and is ready to be automatically be released to the public